### PR TITLE
Update update-docker

### DIFF
--- a/update_docker
+++ b/update_docker
@@ -1,1 +1,1 @@
-solana-localnet update
+npx solana-localnet update


### PR DESCRIPTION
When I ran update-docker on mac, it failed because solana-localnet isn't a valid command. Using `npx` fixed that.
